### PR TITLE
fix sending chat messages with quotes in them

### DIFF
--- a/plugged.js
+++ b/plugged.js
@@ -72,10 +72,11 @@ var CHAT_TIMEOUT_MAX = 700;
 
 WebSocket.prototype.sendMessage = function(type, data) {
     if(typeof type === "string" && (typeof data === "string" || typeof data === "number")) {
-        this.send([
-            '{"a":"', type, '","p":"', data, 
-            '","t":', Date.now(), '}'
-            ].join(''));
+        this.send(JSON.stringify({
+            a: type,
+            p: data,
+            t: Date.now()
+        }));
     }
 };
 


### PR DESCRIPTION
Messages aren't escaped before passing them to sendMessage(). This means that messages with quotes in them will end up creating invalid JSON, which is obviously not accepted by plug.dj.

Instead of concatenating strings (i.e. unsafe hack), we should just use JSON.stringify, which actually *does* produce valid JSON, even if we give it completely ridiculous BS. <3

– PlugLynn/ReAnna