### PR TITLE
fix csrf token offset for plug.dj 1.4

### DIFF
--- a/plugged.js
+++ b/plugged.js
@@ -1662,7 +1662,7 @@ Plugged.prototype.getCSRF = function(callback) {
 
     this.query.query("GET", endpoints["CSRF"], function _gotCSRF(err, body) {
         if(!err) {
-            var idx = body.indexOf("_csrf") + 9;
+            var idx = body.indexOf("_csrf") + 7;
 
             body = body.substr(idx, body.indexOf('\"', idx) - idx);
 


### PR DESCRIPTION
The latest plug.dj update changed a bit of the client-side js, so it now defines the _csrf var as `_csrf="TOKEN"` instead of `_csrf = "TOKEN"`, saving 2 characters.