### PR TITLE
Guest users + chat

### DIFF
--- a/state.js
+++ b/state.js
@@ -110,6 +110,7 @@ var parseUser = function(data) {
         badge: data.badge || "",
         role: data.role || 0,
         sub: data.sub || 0,
+        guest: data.guest || false,
         id: data.id || -1
     };
 };


### PR DESCRIPTION
So plug.dj recently added Guest Users, which are users that aren't logged in and don't have any user data. their behaviour is a bit funny so we have to deal with it in a rather silly way...

When a user joins as a guest, and then logs in, plug.dj doesn't always (but sometimes!) send a new USER_JOIN event. So you might end up with users chatting without joining. This patch first fetches user data from plug.dj before emitting chat events for non-logged-in users.

There's a few non-intuitive things happening in this PR because of this:

 * this might emit chat events out of order, since the next chat event might come in and be fired instantly whilst the current chat event is still waiting for user data to be loaded
 * guest users are _not_ added to the user list, because USER_LEAVE events for guests always have user ID 0, even though guests do have different user IDs. this could be done differently in a future patch: guest users could be added to their own separate array and a random/the first one could be removed when the USER_LEAVE event comes in (guest user data is kinda useless, so it doesn't really matter which is removed)

the _pushUser method now sets the room population to the size of the users list instead of incrementing it, because the USER_JOIN/USER_LEAVE events aren't necessarily 1-to-1 anymore, so things might get out of sync with the real world based purely on those events. in general you end up with more USER_LEAVEs than USER_JOINs in the current situation.

gotta love plug <3