### PR TITLE
Fix gift message parsing

### DIFF
--- a/plugged.js
+++ b/plugged.js
@@ -550,8 +550,9 @@ Plugged.prototype._wsaprocessor = function(self, msg) {
             break;
 
         case self.GIFTED:
-            var user = self.getUserByName(data.p);
-            self.emit(self.GIFTED, user ? user : data.p);
+            var sender = self.getUserByName(data.p.s);
+            var recipient = self.getUserByName(data.p.r);
+            self.emit(self.GIFTED, sender || data.p.s, recipient || data.p.r);
             break;
 
         case self.PLAYLIST_CYCLE:


### PR DESCRIPTION
Gifts have a sender and a recipient, like so:

```json
[{"a":"gifted","p":{"s":"kool_panda","r":"xNinja7"},"s":"loves-kpop"}]
```