### PR TITLE
fix shouldCycle conversion when parsing booth information

### DIFF
--- a/state.js
+++ b/state.js
@@ -406,10 +406,10 @@ var parseBooth = function(data) {
     data = data || {};
 
     return {
-        dj: data.currentDJ || -1,               //id of the active DJ
-        isLocked: data.isLocked || false,       //is waitlist locked?
-        shouldCycle: data.shouldCycle || true,  //should it cycle?
-        waitlist: data.waitingDJs || []         //array of IDs
+        dj: data.currentDJ || -1,                                     //id of the active DJ
+        isLocked: data.isLocked || false,                             //is waitlist locked?
+        shouldCycle: 'shouldCycle' in data ? data.shouldCycle : true, //should it cycle?
+        waitlist: data.waitingDJs || []                               //array of IDs
     };
 };
 


### PR DESCRIPTION
`shouldCycle` will be `false` if DJ Cycle is disabled, so
`shouldCycle || true` will then always result in `true` regardless
of the actual DJ Cycle state. This fix only defaults to `true` if
no `shouldCycle` member is present at all (which should be never,
but *shrug* )

The effect of this was that `doesWaitlistCycle()` would return `true` if the DJ cycle was _disabled_ when the Plugged account joined the room. If the DJ cycle was already enabled, or was changed whilst the account was in the room, the result would be accurate again.