### PR TITLE
add optional node-style callbacks to login() and connect()

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -262,10 +262,20 @@ describe("Login", function () {
     });
 
     describe("#success", function () {
+        beforeEach(function () {
+            client.setJar(null);
+        });
         it("should emit LOGIN_SUCCESS without errors", function (done) {
             client.login({email: testLogin.email, password: testLogin.password});
 
-            client.on(client.LOGIN_SUCCESS, function () {
+            client.once(client.LOGIN_SUCCESS, function () {
+                done();
+            });
+        });
+        it("should work with node-style callbacks", function (done) {
+            client.login({email: testLogin.email, password: testLogin.password}, function (e) {
+                if(e)
+                    throw e;
                 done();
             });
         });
@@ -276,10 +286,17 @@ describe("Joining a room", function () {
     it("should return a room object with the current stats", function (done) {
         client.connect(testLogin.room);
 
-        client.on(client.JOINED_ROOM, function (room) {
+        client.once(client.JOINED_ROOM, function (room) {
             expect(room).to.be.an("object");
-
-
+            done();
+        });
+    });
+    it("should work with node-style callbacks", function (done) {
+        // trying to join the same room twice is fine by plug
+        client.connect(testLogin.room, function (e, room) {
+            if(e)
+                throw e;
+            expect(room).to.be.an("object");
             done();
         });
     });


### PR DESCRIPTION
This should make simple usage quite a lot easier. Previously the only
way to log in looked like:

    plugged.login(myCredentials);
    plugged.on(plugged.LOGIN_SUCCESS, function () {
        // do all my stuff
    });
    plugged.on(plugged.LOGIN_ERROR, function (err) {
        // deal with err
    });

Whereas the usual, and now possible, node way looks more like:

    plugged.login(myCredentials, function (err) {
        if(err) {
             // deal with err
        } else {
             // do all my stuff
        }
    });

As an added bonus, the login() and connect() methods can now be
passed to libraries like Async.js or be automatically promisified in
Bluebird and friends.