### PR TITLE
Fix to prevent bot from crashing when promoting a new host

### DIFF
--- a/plugged.js
+++ b/plugged.js
@@ -659,7 +659,7 @@ Plugged.prototype._wsaprocessor = function(msg, flags) {
             if (promotions.length === 2) {
                 var host = this.getUserByID(this.getHostID());
 
-                for (var i = this.promotions.length - 1; i >= 0; i--) {
+                for (var i = promotions.length - 1; i >= 0; i--) {
                     if(promotions[i].id == host.id) {
                         host.role = promotions.splice(i, 1)[0].role;
 


### PR DESCRIPTION
This is a bug that crashes the bot when promoting a new host since `this.promotions` is undefined.